### PR TITLE
Entry cards display correctly/yuusuf

### DIFF
--- a/app/components/competitions/CompetitionCard.module.css
+++ b/app/components/competitions/CompetitionCard.module.css
@@ -28,6 +28,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   margin-top: 10px;
+  gap: 10px;
 }
 
 .image {

--- a/app/components/entries/EntryCard.jsx
+++ b/app/components/entries/EntryCard.jsx
@@ -113,7 +113,7 @@ export default function EntryCard({
 
       {entryId ? (
         /* real entry → click goes to its own page */
-        <Link href={`/entry/${entryId ?? ''}`} className={styles.imageWrapper}>
+        <Link href={`/entry/${entryId ?? ''}`} className={styles.imageContainer}>
           <img src={image} alt="Entry image" className={styles.image} />
         </Link>
       ) : (
@@ -122,6 +122,7 @@ export default function EntryCard({
       )}
 
       {/* FOOTER: vote count + button */}
+      {(showVoteCount || showActions) && (
       <div className={styles.bottom}>
         {showVoteCount && (
           <div className={styles.voteCount}>
@@ -147,6 +148,7 @@ export default function EntryCard({
           </button>
         )}
       </div>
+          )}
     </div>
   );
 }

--- a/app/components/entries/EntryCard.jsx
+++ b/app/components/entries/EntryCard.jsx
@@ -123,32 +123,36 @@ export default function EntryCard({
 
       {/* FOOTER: vote count + button */}
       {(showVoteCount || showActions) && (
-      <div className={styles.bottom}>
-        {showVoteCount && (
-          <div className={styles.voteCount}>
-            {/* show loader while fetching votes */}
-            {loadingVotes ? <Loader /> : `${votes} stemmer`}
-          </div>
-        )}
-
-        {showActions && (
-          <button
-            onClick={handleVote}
-            disabled={authLoading || loadingVotes || !entryId}
-            className={`${styles.voteButton} ${hasVoted ? styles.voted : ''}`}
-          >
-            {hasVoted ? <FaHeart /> : <FaRegHeart />} Stem
-          </button>
-        )}
-        {/*  share button — only when we also render actions _and_ have a real entry */}
-        {showActions && entryId && (
-          <button onClick={share} className={styles.shareButton}>
-            <img src="/del.png" alt="Del" className={styles.shareIcon} />
-            Del
-          </button>
-        )}
-      </div>
+        <div className={styles.bottom}>
+          {showVoteCount && (
+            <div className={styles.voteCount}>
+              {/* show loader while fetching votes */}
+              {loadingVotes ? <Loader /> : `${votes} stemmer`}
+            </div>
           )}
+
+          {/* grouped action buttons (vote + share) */}
+          {showActions && (
+            <div className={styles.buttonGroupWrapper}>
+              <button
+                onClick={handleVote}
+                disabled={authLoading || loadingVotes || !entryId}
+                className={`${styles.voteButton} ${hasVoted ? styles.voted : ''}`}
+              >
+                {hasVoted ? <FaHeart /> : <FaRegHeart />} Stem
+              </button>
+
+              {/* share button — only when we also render actions _and_ have a real entry */}
+              {entryId && (
+                <button onClick={share} className={styles.shareButton}>
+                  <img src="/del.png" alt="Del" className={styles.shareIcon} />
+                  Del
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/components/entries/EntryCard.module.css
+++ b/app/components/entries/EntryCard.module.css
@@ -1,3 +1,4 @@
+
 .card {
   background: #fff;
   border-radius: 8px;
@@ -9,9 +10,11 @@
 
 /* optional wrapper if you ever need overlays */
 .imageContainer {
+  display: block;
   width: 100%;
-  aspect-ratio: 1 / 1; /* perfect square          */
+  aspect-ratio: 1 / 1;
   position: relative;
+  overflow: hidden; /* helps with cropping */
 }
 
 /* ---------- the image itself ---------- */

--- a/app/components/entries/EntryCard.module.css
+++ b/app/components/entries/EntryCard.module.css
@@ -87,6 +87,6 @@
   gap: 12px;
   border-radius: 30px;
   background: rgba(255 255 255 / 0.8);
-  padding: 6px /* choose your pill width: */ /* 30px;  /* ← PR-50 wider */ 12px; /* ← PR-53 slimmer */
+  padding: 6px 30px;
   margin-top: 8px;
 }


### PR DESCRIPTION
What I did:

- Hid the footer in the EntryCard component when both showActions and showVoteCount are false. This keeps the card cleaner when no buttons or vote counts are needed.

- Added spacing between competition entries by using gap: 10px in the CSS grid layout. This makes the cards easier to see and separates them visually.

- Grouped the vote and share buttons inside a wrapper so they can be styled and positioned together.