### PR TITLE
Turn entry page into a feed while conserving voting and sharing funtionality

### DIFF
--- a/app/api/entries/by-competition/[id]/route.js
+++ b/app/api/entries/by-competition/[id]/route.js
@@ -1,23 +1,67 @@
+import { NextResponse } from 'next/server';
 import dbConnect from '@/utils/dbConnects';
 import Entry from '@/app/api/models/Entry';
-import { NextResponse } from 'next/server';
+import { Types, isValidObjectId } from 'mongoose';
 
 export async function GET(req, { params }) {
-  const { id: competitionId } = await params;
+  const competitionId = params.id;
+  if (!isValidObjectId(competitionId)) {
+    return NextResponse.json(
+      { success: false, message: 'Invalid competitionId' },
+      { status: 400 },
+    );
+  }
+
+  // parse ?limit= & ?skip=
+  const url = new URL(req.url);
+  const limit = parseInt(url.searchParams.get('limit') || '20', 10);
+  const skip = parseInt(url.searchParams.get('skip') || '0', 10);
 
   try {
     await dbConnect();
 
-    const entries = await Entry.find({ competition: competitionId }).select(
-      'imageUrl',
-    );
+    // this is an attempt at creating a trend algorithm, compute trendingScore = votes / hoursOld
+    const now = new Date();
+    const pipeline = [
+      { $match: { competition: new Types.ObjectId(competitionId) } },
+      {
+        $addFields: {
+          hoursOld: {
+            $divide: [{ $subtract: [now, '$createdAt'] }, 1000 * 60 * 60],
+          },
+        },
+      },
+      {
+        $addFields: {
+          trendingScore: {
+            $cond: [
+              { $gt: ['$hoursOld', 0] },
+              { $divide: ['$votes', '$hoursOld'] },
+              '$votes',
+            ],
+          },
+        },
+      },
+      { $sort: { trendingScore: -1 } },
+      { $skip: skip },
+      { $limit: limit },
+      // project only the fields your client needs:
+      {
+        $project: {
+          imageUrl: 1,
+          caption: 1,
+          participant: 1,
+          votes: 1,
+          createdAt: 1,
+        },
+      },
+    ];
 
-    return NextResponse.json({
-      success: true,
-      data: entries,
-    });
-  } catch (error) {
-    console.error('Error fetching entries:', error);
+    const entries = await Entry.aggregate(pipeline);
+
+    return NextResponse.json({ success: true, data: entries });
+  } catch (err) {
+    console.error('Error in by-competition route:', err);
     return NextResponse.json(
       { success: false, message: 'Server error' },
       { status: 500 },

--- a/app/competition/create/page.jsx
+++ b/app/competition/create/page.jsx
@@ -1,6 +1,0 @@
-'use client';
-import CompetitionForm from '../../components/competitionCreationForm/competitionCreationForm';
-
-export default function () {
-  return <CompetitionForm />;
-}

--- a/app/entry/[id]/page.jsx
+++ b/app/entry/[id]/page.jsx
@@ -42,7 +42,7 @@ export default function EntryPage() {
         const all = Array.isArray(listRes.data) ? listRes.data : [];
         // 4) filter out the clicked one
         const rest = all.filter((e) => e._id !== id);
-        // 5) build and set your feed
+        // 5) build and set the feed
         const initial = [clicked, ...rest];
         setFeed(initial);
 
@@ -109,7 +109,6 @@ export default function EntryPage() {
       } else {
         // remove existing vote
         const recordId = recordIdMap[entryId]; // ← grab the right one
-        console.log('⚠️ Deleting vote with id:', recordId);
         await API.delete(`/votes/${recordId}`);
         setVotedMap((m) => ({ ...m, [entryId]: false }));
         setVotesMap((m) => ({ ...m, [entryId]: Math.max(m[entryId] - 1, 0) }));

--- a/app/entry/[id]/page.jsx
+++ b/app/entry/[id]/page.jsx
@@ -7,91 +7,174 @@ import API from '@/utils/axios';
 import Loader from '@/app/components/loader/Loader';
 import { useAuth } from '@/context/AuthContext';
 import styles from '../entryPage.module.css';
-
-const PLACEHOLDER_IMG = 'https://picsum.photos/600/400?grayscale&blur=1';
+import { DEFAULT_AVATAR, PLACEHOLDER_IMG } from '@/utils/constants';
 
 export default function EntryPage() {
-  const { id } = useParams();
+  const { id } = useParams(); //  clicked entry ID
   const { user, loading: authLoading } = useAuth();
 
-  const [entry, setEntry] = useState(null);
-  const [votes, setVotes] = useState(0);
-  const [hasVoted, setHasVoted] = useState(false);
-  const [voteRecId, setVoteRecId] = useState(null);
+  // feed state + pagination
+  const [feed, setFeed] = useState([]);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(true);
-  const [voting, setVoting] = useState(false);
 
-  /* ------------- 1. load entry + vote info ---------------- */
+  // per-entry maps for loading & vote state
+  const [votingMap, setVotingMap] = useState({});
+  const [votedMap, setVotedMap] = useState({});
+  const [votesMap, setVotesMap] = useState({});
+  const [recordIdMap, setRecordIdMap] = useState({});
+
+  /* ------------- 1. load entry + feed page 0 ---------------- */
   useEffect(() => {
-    async function load() {
+    async function loadFeed() {
       setLoading(true);
       try {
-        // entry doc
-        const { data: e } = await API.get(`/entries/${id}`);
-        // votes + my vote
-        const { data: v } = await API.get('/votes/me', {
-          params: { entryId: id },
-        });
+        // 1) fetch the clicked entry
+        const { data: clicked } = await API.get(`/entries/${id}`);
+        // 2) pull competition ID off it
+        const compId = clicked.competition;
+        // 3) fetch first 20 trending in same comp
+        const { data: listRes } = await API.get(
+          `/entries/by-competition/${compId}`,
+          { params: { limit: 20, skip: 0, sort: 'trending' } },
+        );
+        const all = Array.isArray(listRes.data) ? listRes.data : [];
+        // 4) filter out the clicked one
+        const rest = all.filter((e) => e._id !== id);
+        // 5) build and set your feed
+        const initial = [clicked, ...rest];
+        setFeed(initial);
 
-        setEntry(e);
-        if (v.success) {
-          setVotes(v.votes);
-          setHasVoted(v.hasVoted);
-          setVoteRecId(v.recordId);
-        }
+        // initialize vote maps
+        const voting = {},
+          voted = {},
+          votes = {},
+          records = {};
+        await Promise.all(
+          initial.map(async (e) => {
+            const { data: v } = await API.get('/votes/me', {
+              params: { entryId: e._id },
+            });
+            voting[e._id] = false;
+            if (v.success) {
+              voted[e._id] = v.hasVoted;
+              votes[e._id] = v.votes;
+              records[e._id] = v.recordId; // ← store record ID
+            } else {
+              voted[e._id] = false;
+              votes[e._id] = e.votes || 0;
+              records[e._id] = null;
+            }
+          }),
+        );
+        setVotingMap(voting);
+        setVotedMap(voted);
+        setVotesMap(votes);
+        setRecordIdMap(records);
+
+        // prep next page
+        setPage(1);
+        setHasMore(all.length === 20);
       } catch (err) {
-        console.error('Failed to load entry page:', err);
+        console.error('Failed to load feed:', err);
       } finally {
         setLoading(false);
       }
     }
-    load();
+    loadFeed();
   }, [id]);
 
   /* ------------- 2. toggle vote --------------------------- */
-  const toggleVote = async () => {
-    if (authLoading || voting) return;
-
+  const toggleVote = async (entryId) => {
+    if (authLoading || votingMap[entryId]) return;
     if (!user) {
-      // not logged-in → redirect to /login
       window.location.href = '/login';
       return;
     }
-
-    setVoting(true);
+    setVotingMap((m) => ({ ...m, [entryId]: true }));
     try {
-      if (!hasVoted) {
-        // add like
+      if (!votedMap[entryId]) {
+        // cast new vote
         const { data } = await API.post('/votes', {
-          entry: id,
+          entry: entryId,
           voteType: 'like',
         });
         if (data.success) {
-          setVotes((v) => v + 1);
-          setHasVoted(true);
-          setVoteRecId(data.vote._id);
+          setVotedMap((m) => ({ ...m, [entryId]: true }));
+          setVotesMap((m) => ({ ...m, [entryId]: m[entryId] + 1 }));
+          // also store the new recordId so we can delete it next time
+          setRecordIdMap((m) => ({ ...m, [entryId]: data.vote._id }));
         }
       } else {
-        // remove like
-        await API.delete(`/votes/${voteRecId}`);
-        setVotes((v) => Math.max(v - 1, 0));
-        setHasVoted(false);
-        setVoteRecId(null);
+        // remove existing vote
+        const recordId = recordIdMap[entryId]; // ← grab the right one
+        console.log('⚠️ Deleting vote with id:', recordId);
+        await API.delete(`/votes/${recordId}`);
+        setVotedMap((m) => ({ ...m, [entryId]: false }));
+        setVotesMap((m) => ({ ...m, [entryId]: Math.max(m[entryId] - 1, 0) }));
+        // clear it out
+        setRecordIdMap((m) => ({ ...m, [entryId]: null }));
       }
     } catch (err) {
       console.error('Vote error:', err);
     } finally {
-      setVoting(false);
+      setVotingMap((m) => ({ ...m, [entryId]: false }));
     }
   };
 
   /* ------------- 3. share (simple clipboard copy) --------- */
-  const share = async () => {
+  const shareEntry = (entryId) => {
+    const url = `${window.location.origin}/entry/${entryId}`;
+    navigator.clipboard
+      .writeText(url)
+      .then(() => alert('Link copied to clipboard 📋'))
+      .catch(() => alert('Could not copy link'));
+  };
+
+  /* ------------- 4. Load more handler --------- */
+  const loadMore = async () => {
+    if (!hasMore) return;
+    setLoading(true);
     try {
-      await navigator.clipboard.writeText(window.location.href);
-      alert('Link copied to clipboard 📋');
-    } catch {
-      alert('Could not copy link');
+      // competition lives on feed[0].competition
+      const compId = feed[0].competition;
+      const skip = page * 20;
+      const { data: listRes } = await API.get(
+        `/entries/by-competition/${compId}`,
+        { params: { limit: 20, skip, sort: 'trending' } },
+      );
+      const next = Array.isArray(listRes.data) ? listRes.data : [];
+      // append
+      setFeed((f) => [...f, ...next]);
+      // init vote maps for new items
+      setVotingMap((m) => {
+        const copy = { ...m };
+        next.forEach((e) => {
+          copy[e._1d] = false;
+        });
+        return copy;
+      });
+      setVotedMap((m) => {
+        const copy = { ...m };
+        next.forEach((e) => {
+          copy[e._id] = false;
+        });
+        return copy;
+      });
+      setVotesMap((m) => {
+        const copy = { ...m };
+        next.forEach((e) => {
+          copy[e._id] = e.votes || 0;
+        });
+        return copy;
+      });
+      setPage((p) => p + 1);
+      setHasMore(next.length === 20);
+    } catch (err) {
+      console.error('Load more failed:', err);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -100,35 +183,58 @@ export default function EntryPage() {
 
   return (
     <main className={styles.main}>
-      {/* ── 1. username ── */}
-      <h3 className={styles.title}>
-        {entry?.participant?.userName ?? 'Ukendt deltager'}
-      </h3>
+      {feed.map((entryDoc) => (
+        <section key={entryDoc._id} className={styles.entryWrapper}>
+          {/* ── 1. username & avatar ── */}
+          <div className={styles.header}>
+            <img
+              src={entryDoc.participant?.avatarUrl || DEFAULT_AVATAR}
+              alt={entryDoc.participant?.userName || 'Deltager'}
+              className={styles.avatar}
+            />
+            <span className={styles.title}>
+              {entryDoc.participant?.userName ?? 'Ukendt deltager'}
+            </span>
+          </div>
 
-      {/* ── 2. image ── */}
-      <img
-        className={styles.image}
-        src={entry.imageUrl || PLACEHOLDER_IMG}
-        alt="Entry"
-      />
+          {/* ── 2. image ── */}
+          <img
+            className={styles.image}
+            src={entryDoc.imageUrl ?? PLACEHOLDER_IMG}
+            alt="Entry"
+          />
 
-      {/* ── 3. vote count + buttons ── */}
-      <div className={styles.actions}>
-        <button
-          onClick={toggleVote}
-          disabled={authLoading || voting}
-          className={`${styles.voteBtn} ${hasVoted ? styles.voted : ''}`}
-        >
-          {hasVoted ? <FaHeart /> : <FaRegHeart />} {votes}
+          {/* ── 3. vote count + buttons ── */}
+          <div className={styles.actions}>
+            <button
+              onClick={() => toggleVote(entryDoc._id)}
+              disabled={authLoading || votingMap[entryDoc._id]}
+              className={`${styles.voteBtn} ${votedMap[entryDoc._id] ? styles.voted : ''}`}
+            >
+              {votedMap[entryDoc._id] ? <FaHeart /> : <FaRegHeart />}{' '}
+              {votesMap[entryDoc._id] ?? 0}
+            </button>
+            <button
+              onClick={() => shareEntry(entryDoc._id)}
+              className={styles.shareBtn}
+            >
+              <FaShareAlt /> Del
+            </button>
+          </div>
+
+          {/* ── 4. description / caption ── */}
+          {entryDoc.caption && (
+            <p className={styles.caption}>{entryDoc.caption}</p>
+          )}
+        </section>
+      ))}
+
+      {/* ── 5. load more ── */}
+      {hasMore && !loading && (
+        <button className={styles.loadMore} onClick={loadMore}>
+          Load more
         </button>
-
-        <button onClick={share} className={styles.shareBtn}>
-          <FaShareAlt /> Del
-        </button>
-      </div>
-
-      {/* ── 4. description / caption ── */}
-      {entry.caption && <p className={styles.caption}>{entry.caption}</p>}
+      )}
     </main>
   );
 }

--- a/app/entry/entryPage.module.css
+++ b/app/entry/entryPage.module.css
@@ -1,3 +1,9 @@
+/* container for each entry in the feed */
+.entryWrapper {
+  margin-bottom: 2.5rem;
+}
+
+/* main page wrapper */
 .main {
   padding: 2rem;
   max-width: 800px;
@@ -5,11 +11,29 @@
   text-align: center;
 }
 
-.title {
+/* header: avatar + username */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   margin-bottom: 1rem;
-  font-size: 2rem;
 }
 
+/* avatar image */
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+/* username/title */
+.title {
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+/* entry image */
 .image {
   width: 100%;
   max-height: 500px;
@@ -18,12 +42,15 @@
   margin-bottom: 1rem;
 }
 
+/* actions row: vote + share */
 .actions {
   display: flex;
   justify-content: center;
   gap: 1rem;
+  margin-bottom: 1rem;
 }
 
+/* vote & share buttons */
 .voteBtn,
 .shareBtn {
   display: flex;
@@ -31,11 +58,13 @@
   gap: 0.4rem;
   border: none;
   cursor: pointer;
-  padding: 0.6rem 1.2rem;
+  padding: 0.5rem 1rem;
   border-radius: 30px;
-  font-size: 1rem;
+  font-size: 0.95rem;
+  transition: background 0.2s;
 }
 
+/* vote button default & “voted” state */
 .voteBtn {
   background: #000;
   color: #fff;
@@ -44,7 +73,46 @@
   background: #d62828;
 }
 
+/* share button */
 .shareBtn {
   background: #868483;
-  color: white;
+  color: #fff;
+}
+
+/* caption / description */
+.caption {
+  font-size: 1rem;
+  line-height: 1.4;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+/* “Load more” button */
+.loadMore {
+  display: block;
+  margin: 1.5rem auto;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border: none;
+  background: #0055ff;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.loadMore:hover {
+  opacity: 0.9;
+}
+
+/* Responsive tweaks */
+@media (max-width: 600px) {
+  .actions {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .voteBtn,
+  .shareBtn {
+    width: 100%;
+    justify-content: center;
+  }
 }

--- a/app/signup/SignupPage.module.css
+++ b/app/signup/SignupPage.module.css
@@ -1,6 +1,6 @@
 .container {
   padding-top: 150px;
-  position: absolute;;
+  position: absolute;
 }
 
 .wrapper {
@@ -15,7 +15,7 @@
 .backButton {
   margin-bottom: 100px;
   text-align: right;
-  position:fixed;
+  position: fixed;
   font-weight: 500;
   color: black;
   text-decoration: none;

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,2 @@
+export const DEFAULT_AVATAR = 'https://avatar.iran.liara.run/public';
+export const PLACEHOLDER_IMG = 'https://picsum.photos/600/400?grayscale&blur=1';


### PR DESCRIPTION
Summary of changes
This PR transforms the single‐entry page into a scrollable feed of entries within the same competition, while preserving all existing vote & share behaviors. Key updates:

1. Feed loading

- Fetch the clicked entry, then fetch the first batch of “trending” entries for that competition (votes / hours since creation).

- Filter out the clicked entry, then render [clickedEntry, …otherEntries].

2. Per‐entry vote state

- Introduce three state maps:

    - votingMap[entryId] → whether an entry’s vote button is currently loading
    
    - votedMap[entryId] → whether the current user has liked that entry
     
    - votesMap[entryId] → the current total vote count

- Add a fourth recordIdMap[entryId] to store the Mongo vote‐document ID, so we can issue DELETE calls when un‐liking.

3. Toggle‐vote handler

- On “Like”: POST to /votes, then update maps (votedMap, votesMap, recordIdMap).

- On “Unlike”: DELETE to /votes/{recordId} from recordIdMap, then clear maps.

4. Share button

- Each card’s share button copies its entry’s URL (/entry/{id}) to clipboard with user feedback.

5. Pagination (“Load more”)

- A centered “Load more” button fetches the next batch (skip = page × limit) and appends to feed, initializing vote & record maps for new entries.

6. Constants refactor

- Moved placeholder image for default avatar URLs into utils/constants.js and imported it. 

finaly, I also deleted a redundant orphaned competition/creation page 